### PR TITLE
disable bracketed paste mode with ~/.inputrc

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -24,6 +24,11 @@ TMPDIR="$(mktemp -d)"
 export WORKING_DIR="<%= session.staged_root %>"
 export RSTUDIO_AUTH="$WORKING_DIR/bin/auth"
 
+#This is to resolve issue : https://github.com/nesi/nesi-ood-rstudio-server-app/issues/13
+if [ ! -f ~/.inputrc ] || ! grep -qF 'set enable-bracketed-paste off' ~/.inputrc; then
+    echo 'set enable-bracketed-paste off' >> ~/.inputrc
+fi
+
 #Try above first as auth wasn't working correctly with the following
 #export RSTUDIO_AUTH="${PWD}/bin/auth"
 


### PR DESCRIPTION
Proposing this as a permanent solution for #13 

* RStudio's terminal paste issue is related to bracketed paste mode, a terminal feature that wraps pasted text in escape sequences (e.g., ^[[200~).  Easiest and probably the cleanest solution it so to disable bracketed paste mode in terminals using Readline 